### PR TITLE
删除Tag的时候，让搜索框不自动获取焦点。

### DIFF
--- a/askbot/media/js/searchbar/full_text_search.js
+++ b/askbot/media/js/searchbar/full_text_search.js
@@ -237,8 +237,6 @@ FullTextSearch.prototype.renderFullTextSearchResult = function (data) {
         askHrefBase + data.query_data.ask_query_string
     ); /* INFO: ask_query_string should already be URL-encoded! */
 
-    this._query.focus();
-
     var old_list = $('#' + this._q_list_sel);
     var new_list = $('<div></div>').hide().html(data.questions);
     new_list.find('.timeago').timeago();


### PR DESCRIPTION
#12 
如果让它自动获取焦点，输入框又会弹出来，很不友好。